### PR TITLE
Skip comments in FQL files

### DIFF
--- a/fauna/baseEvalFqlQuery.js
+++ b/fauna/baseEvalFqlQuery.js
@@ -26,13 +26,39 @@ function parseQuery(code) {
   }
   const openBrackets = new Set(Object.keys(brackets))
   const closeBrackets = new Set(Object.values(brackets))
+  const newLines = new Set("\r", "\n")
   const queries = []
   const stack = []
   let start = 0
   let isOpening
+  let inLineComment
+  let inBlockComment
   code = code.trim()
 
   for (let i = 0; i < code.length; i++) {
+    if (inLineComment) {
+      if (newLines.has(code[i])) {
+        inLineComment = false
+      } else {
+        continue
+      }
+    }
+    if (inBlockComment) {
+      if (code[i] == "*" && code[i + 1] == "/") {
+        inBlockComment = false
+      } else {
+        continue
+      }
+    }
+
+    if (code[i] == "/") {
+      if (code[i + 1] == "/") {
+        inLineComment = true
+      } else if (code[i + 1] == "*") {
+        inBlockComment = true
+      }
+    }
+
     if (openBrackets.has(code[i])) {
       stack.push(code[i])
       isOpening = true


### PR DESCRIPTION
I'm trying to deploy an FQL function from a file that looks like the following, but the framework doesn't seem to take into account comments and tells me that I can only have one function per file.

```
// Lambda(
// ...
// )
Lambda(
...
)
```

I don't see examples of testing this sort of use-case, so I'm not sure how that should happen.