### PR TITLE
Exceptions cause return code 1

### DIFF
--- a/commands/DeployCommand.js
+++ b/commands/DeployCommand.js
@@ -71,6 +71,7 @@ class DeployCommand {
       }
     } catch (error) {
       this.logger.error(error)
+      throw error;
     }
   }
 

--- a/tests/config/.gitignore
+++ b/tests/config/.gitignore
@@ -1,0 +1,1 @@
+.serverless

--- a/tests/config/fail-invalid-collection.yml
+++ b/tests/config/fail-invalid-collection.yml
@@ -15,3 +15,7 @@ fauna:
       name: Movies
       data:
         some_data_key: some_data_value
+  indexes:
+    movies_ts:
+      name: movies_ts
+      source: movies but oh look i typoed right here so this is going to fail

--- a/tests/config/fail-invalid-collection.yml
+++ b/tests/config/fail-invalid-collection.yml
@@ -11,11 +11,11 @@ fauna:
     port: 9001
     scheme: http
   collections:
-    Movies:
-      name: Movies
+    movies:
+      name: movies
       data:
         some_data_key: some_data_value
   indexes:
-    movies_ts:
-      name: movies_ts
+    movies_ts_1:
+      name: movies_ts_1
       source: movies but oh look i typoed right here so this is going to fail

--- a/tests/config/fail-invalid-collection.yml
+++ b/tests/config/fail-invalid-collection.yml
@@ -11,11 +11,11 @@ fauna:
     port: 9001
     scheme: http
   collections:
-    movies:
-      name: movies
+    movies_1:
+      name: movies_1
       data:
         some_data_key: some_data_value
   indexes:
     movies_ts_1:
       name: movies_ts_1
-      source: movies but oh look i typoed right here so this is going to fail
+      source: movies_1 but oh look i typoed right here so this is going to fail

--- a/tests/config/fail-invalid-collection.yml
+++ b/tests/config/fail-invalid-collection.yml
@@ -8,7 +8,7 @@ fauna:
   client:
     secret: secret
     domain: localhost
-    port: 8443
+    port: 9001
     scheme: http
   collections:
     Movies:

--- a/tests/config/fail-invalid-collection.yml
+++ b/tests/config/fail-invalid-collection.yml
@@ -13,8 +13,6 @@ fauna:
   collections:
     movies_1:
       name: movies_1
-      data:
-        some_data_key: some_data_value
   indexes:
     movies_ts_1:
       name: movies_ts_1

--- a/tests/config/fail-invalid-secret.yml
+++ b/tests/config/fail-invalid-secret.yml
@@ -2,7 +2,7 @@ provider:
   name: "aws"
 plugins:
   # - "@fauna-labs/serverless-fauna"
-  - "."
+  - "../../"
 service: "foo"
 fauna:
   client:

--- a/tests/config/fail-invalid-secret.yml
+++ b/tests/config/fail-invalid-secret.yml
@@ -6,12 +6,10 @@ plugins:
 service: "foo"
 fauna:
   client:
-    secret: invalid secret
+    secret: hey look at me i'm an invalid secret so this should fail and exit with code 1
     domain: localhost
     port: 9001
     scheme: http
   collections:
     movies:
       name: movies
-      data:
-        some_data_key: some_data_value

--- a/tests/config/fail-invalid-secret.yml
+++ b/tests/config/fail-invalid-secret.yml
@@ -8,7 +8,7 @@ fauna:
   client:
     secret: invalid secret
     domain: localhost
-    port: 8443
+    port: 9001
     scheme: http
   collections:
     Movies:

--- a/tests/config/fail-invalid-secret.yml
+++ b/tests/config/fail-invalid-secret.yml
@@ -11,7 +11,7 @@ fauna:
     port: 9001
     scheme: http
   collections:
-    Movies:
-      name: Movies
+    movies:
+      name: movies
       data:
         some_data_key: some_data_value

--- a/tests/config/failure.yml
+++ b/tests/config/failure.yml
@@ -1,0 +1,17 @@
+provider:
+  name: "aws"
+plugins:
+  # - "@fauna-labs/serverless-fauna"
+  - "."
+service: "foo"
+fauna:
+  client:
+    secret: invalid secret
+    domain: localhost
+    port: 8443
+    scheme: http
+  collections:
+    Movies:
+      name: Movies
+      data:
+        some_data_key: some_data_value

--- a/tests/config/valid.yml
+++ b/tests/config/valid.yml
@@ -11,11 +11,11 @@ fauna:
     port: 9001
     scheme: http
   collections:
-    movies:
-      name: movies
+    movies_2:
+      name: movies_2
       data:
         some_data_key: some_data_value
   indexes:
     movies_ts_2:
       name: movies_ts_2
-      source: movies
+      source: movies_2

--- a/tests/config/valid.yml
+++ b/tests/config/valid.yml
@@ -11,7 +11,11 @@ fauna:
     port: 9001
     scheme: http
   collections:
-    Movies:
-      name: Movies
+    movies:
+      name: movies
       data:
         some_data_key: some_data_value
+  indexes:
+    movies_ts_2:
+      name: movies_ts_2
+      source: movies

--- a/tests/config/valid.yml
+++ b/tests/config/valid.yml
@@ -1,0 +1,17 @@
+provider:
+  name: "aws"
+plugins:
+  # - "@fauna-labs/serverless-fauna"
+  - "."
+service: "foo"
+fauna:
+  client:
+    secret: secret
+    domain: localhost
+    port: 8443
+    scheme: http
+  collections:
+    Movies:
+      name: Movies
+      data:
+        some_data_key: some_data_value

--- a/tests/config/valid.yml
+++ b/tests/config/valid.yml
@@ -13,8 +13,6 @@ fauna:
   collections:
     movies_2:
       name: movies_2
-      data:
-        some_data_key: some_data_value
   indexes:
     movies_ts_2:
       name: movies_ts_2

--- a/tests/config/valid.yml
+++ b/tests/config/valid.yml
@@ -8,7 +8,7 @@ fauna:
   client:
     secret: secret
     domain: localhost
-    port: 8443
+    port: 9001
     scheme: http
   collections:
     Movies:

--- a/tests/exitCodes.test.js
+++ b/tests/exitCodes.test.js
@@ -1,0 +1,14 @@
+const { promisify } = require('util');
+const exec = promisify(require('child_process').exec);
+const assert = require('assert');
+
+// This test requires a local fauna container to be running.
+describe('deploy exit codes', () => {
+  jest.setTimeout(30000);
+  test('exit code 1', async () => {
+    await assert.rejects(async () => await exec("sls deploy -c tests/config/failure.yml"));
+  });
+  test('exit code 0', async () => {
+    await exec("sls deploy -c tests/config/valid.yml");
+  });
+});

--- a/tests/exitCodes.test.js
+++ b/tests/exitCodes.test.js
@@ -29,8 +29,8 @@ describe('deploy exit codes', () => {
   test('exit code 0', async () => {
     await exec_sls_work("valid.yml");
     await assert_matches(client, {
-      collections: [ "movies" ],
-      indexes: [ "movies_ts" ],
+      collections: [ "movies_2" ],
+      indexes: [ "movies_ts_2" ],
     });
   });
 });

--- a/tests/exitCodes.test.js
+++ b/tests/exitCodes.test.js
@@ -1,12 +1,18 @@
 const { promisify } = require('util');
 const spawn = require('child_process').spawn;
+const exec = promisify(require('child_process').exec);
 const assert = require('assert');
 
 // This test requires a local fauna container to be running.
 jest.setTimeout(30000);
-test('deploy exit codes', async () => {
-  const client = await start_db();
-  /*
+describe('deploy exit codes', () => {
+  beforeAll(async () => {
+    await start_db();
+  });
+  afterAll(async () => {
+    await stop_db();
+  });
+  // const client = get_client();
   // TODO: Make sure the db is empty here
   test('exit code 1', async () => {
     await assert.rejects(async () => await exec("sls deploy -c fail-invalid-secret.yml", { "cwd": `${__dirname}/config` }));
@@ -20,9 +26,6 @@ test('deploy exit codes', async () => {
     await exec("sls deploy -c valid.yml", { "cwd": `${__dirname}/config` });
   });
   // TODO: Make sure the db has a collection here
-  // TODO: Stop db in catch here
-  */
-  await stop_db();
 });
 
 async function start_db(docker) {

--- a/tests/exitCodes.test.js
+++ b/tests/exitCodes.test.js
@@ -6,9 +6,9 @@ const assert = require('assert');
 describe('deploy exit codes', () => {
   jest.setTimeout(30000);
   test('exit code 1', async () => {
-    await assert.rejects(async () => await exec("sls deploy -c tests/config/failure.yml"));
+    await assert.rejects(async () => await exec("sls deploy -c failure.yml"), { "cwd": "./tests/config" });
   });
   test('exit code 0', async () => {
-    await exec("sls deploy -c tests/config/valid.yml");
+    await exec("sls deploy -c valid.yml", { "cwd": "./tests/config" });
   });
 });

--- a/tests/exitCodes.test.js
+++ b/tests/exitCodes.test.js
@@ -5,10 +5,18 @@ const assert = require('assert');
 // This test requires a local fauna container to be running.
 describe('deploy exit codes', () => {
   jest.setTimeout(30000);
+  // TODO: Start db here
+  // TODO: Make sure the db is empty here
   test('exit code 1', async () => {
-    await assert.rejects(async () => await exec("sls deploy -c failure.yml"), { "cwd": "./tests/config" });
+    await assert.rejects(async () => await exec("sls deploy -c fail-invalid-secret.yml", { "cwd": `${__dirname}/config` }));
   });
+  // TODO: Make sure the db is empty here
+  test('exit code 1', async () => {
+    await assert.rejects(async () => await exec("sls deploy -c fail-invalid-collection.yml", { "cwd": `${__dirname}/config` }));
+  });
+  // TODO: Make sure the db is empty here
   test('exit code 0', async () => {
-    await exec("sls deploy -c valid.yml", { "cwd": "./tests/config" });
+    await exec("sls deploy -c valid.yml", { "cwd": `${__dirname}/config` });
   });
+  // TODO: Make sure the db has a collection here
 });

--- a/tests/exitCodes.test.js
+++ b/tests/exitCodes.test.js
@@ -1,11 +1,12 @@
 const { promisify } = require('util');
-const exec = promisify(require('child_process').exec);
+const spawn = require('child_process').spawn;
 const assert = require('assert');
 
 // This test requires a local fauna container to be running.
-describe('deploy exit codes', () => {
-  jest.setTimeout(30000);
-  // TODO: Start db here
+jest.setTimeout(30000);
+test('deploy exit codes', async () => {
+  const client = await start_db();
+  /*
   // TODO: Make sure the db is empty here
   test('exit code 1', async () => {
     await assert.rejects(async () => await exec("sls deploy -c fail-invalid-secret.yml", { "cwd": `${__dirname}/config` }));
@@ -19,4 +20,35 @@ describe('deploy exit codes', () => {
     await exec("sls deploy -c valid.yml", { "cwd": `${__dirname}/config` });
   });
   // TODO: Make sure the db has a collection here
+  // TODO: Stop db in catch here
+  */
+  await stop_db();
 });
+
+async function start_db(docker) {
+  console.log("Starting local FaunaDB instance...");
+  // This is much clearer than using the nodejs docker api, and much simpler.
+  let child = spawn("docker", ["run", "--rm", "--name", "faunadb-sls-test", "-p", "9001:8443", "fauna/faunadb"]);
+  let read_number = 0;
+  await new Promise((resolve, reject) => {
+    child.stdout.on("data", function(data) {
+      if (data.toString().trim() == "FaunaDB is ready.") {
+        read_number += 1;
+      }
+      if (read_number == 2) {
+        resolve();
+      }
+    });
+    child.on('close', resolve);
+  });
+  console.log("FaunaDB has started!");
+}
+
+async function stop_db(docker) {
+  console.log("Stopping local FaunaDB instance...");
+  let child = spawn("docker", ["stop", "faunadb-sls-test"]);
+  await new Promise((resolve, reject) => {
+    child.on('close', resolve);
+  });
+  console.log("Stopped FaunaDB");
+}


### PR DESCRIPTION
Previously, all exceptions were caught, and serverless would simply log the error and return exit
code 0. This made it impossible to check if the upload failed, and made failures undetectable in
pipelines.

After this change, failures will now crash the serverless plugin entirely, and make it return exit
code 1.

This also adds extensive tests, which start a local container, and run serverless against that local
container. There is also a split database as part of the tests [here](https://github.com/fauna-labs/serverless-fauna/pull/20/files#diff-37b148d8b886d70656f7e8d75e3b3355f83c26cf8178c3e2cae94516021cb3d7R26), which is commented out. That test
will be re-enabled once #21 gets merged.

# How to run

The tests added here can be run with
```
npm test exit -- --silent=false
```

Note that both `docker` and `sls` need to be in your PATH. Some othere tests are failing, so the "exit" part of that command specifically runs the tests with the name "exit" in them. The `--silent=false` is because we log a bunch of things, and the test can take a while to run (it takes 35s on my computer).