### PR TITLE
[FE-2440] Fix comment handling bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 /coverage/
 /testConfig.json
+yarn.lock

--- a/fauna/baseEvalFqlQuery.js
+++ b/fauna/baseEvalFqlQuery.js
@@ -58,7 +58,10 @@ function parseQuery(code) {
         inBlockComment = true
         i += 1
       }
-      continue
+
+      if (inLineComment || inBlockComment) {
+        continue
+      }
     }
 
     if (inQuery) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fauna-labs/serverless-fauna",
-  "version": "0.1.4",
+  "version": "0.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fauna-labs/serverless-fauna",
-      "version": "0.1.4",
+      "version": "0.1.6",
       "license": "MIT-0",
       "dependencies": {
         "faunadb": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fauna-labs/serverless-fauna",
-  "version": "0.1.4",
+  "version": "0.1.6",
   "description": "A plugin to define resources in your Fauna database directly within your Serverless Framework applications.",
   "main": "index.js",
   "scripts": {

--- a/tests/fauna/DeployQueries.test.js
+++ b/tests/fauna/DeployQueries.test.js
@@ -28,9 +28,7 @@ describe('Fauna deploy', () => {
   let dbRef
   const BaseFQLValue = new values.Query({
     lambda: 'ref',
-    expr: {
-      var: 'ref',
-    },
+    expr: [ { var: 'ref' }, "this/is/not/a/comment" ],
     api_version: '4',
   })
 

--- a/tests/test.data.js
+++ b/tests/test.data.js
@@ -1,7 +1,19 @@
-const { query: q, Expr } = require('faunadb')
+const { query: q } = require('faunadb')
 
-const BaseFQL = q.Lambda('ref', q.Var('ref'))
-const BaseFQLString = Expr.toString(BaseFQL)
+const BaseFQL = q.Lambda('ref', [ q.Var('ref'), "this/is/not/a/comment" ])
+const BaseFQLString = `
+/*
+ * Leading comment block
+ */
+Lambda(
+  "ref", // Comment
+  // Comment
+  [
+    Var("ref" /* Inline comment */),
+    "this/is/not/a/comment"
+  ]
+)
+`
 
 const defaultData = {
   created_by_serverless_plugin: true,


### PR DESCRIPTION
In v0.1.4, the improved comment handling introduced a bug where forward-slashes `/` that were not part of a comment would get stripped out because the conditional looking for slashes would `continue` the surrounding for-loop rather than first checking if the slash was inside a comment.  This PR fixes the bug and adds some test coverage by adding comment lines and non-comment slashes to test data.