### PR TITLE
Deletion Policy on Every Resource

### DIFF
--- a/commands/DeployCommand.js
+++ b/commands/DeployCommand.js
@@ -88,16 +88,23 @@ class DeployCommand {
   }
 
   mergeMetadata({ data = {}, deletion_policy = "destroy" }) {
+    if (deletion_policy !== "destroy" && deletion_policy !== "retain") {
+      throw new Error(`invalid deletion policty: '${deletion_policy}' (expected 'destroy' or 'retain')`)
+    }
     return { ...this.defaultMetadata, ...data, deletion_policy }
   }
 
   collectionAdapter(collection) {
-    return {
-      ...collection,
-      data: this.mergeMetadata({
-        data: collection.data,
-        deletion_policy: collection.deletion_policy,
-      }),
+    try {
+      return {
+        ...collection,
+        data: this.mergeMetadata({
+          data: collection.data,
+          deletion_policy: collection.deletion_policy,
+        }),
+      }
+    } catch (error) {
+      throw new Error(`collection.${collection.name}: ${error.message}`)
     }
   }
 

--- a/commands/DeployCommand.js
+++ b/commands/DeployCommand.js
@@ -18,6 +18,14 @@ class DeployCommand {
   }
 
   constructor({ config, faunaClient, logger }) {
+    if (config.deletion_policy !== undefined) {
+      try {
+        this.validateDeletionPolicty(config.deletion_policy)
+      } catch (e) {
+        logger.error(e);
+        throw e;
+      }
+    }
     this.config = config
     this.faunaClient = faunaClient
     this.logger = logger
@@ -87,10 +95,14 @@ class DeployCommand {
     throw new Error([name, error.description].join(' => '))
   }
 
-  mergeMetadata({ data = {}, deletion_policy = "destroy" }) {
+  validateDeletionPolicty(deletion_policy) {
     if (deletion_policy !== "destroy" && deletion_policy !== "retain") {
       throw new Error(`invalid deletion policty: '${deletion_policy}' (expected 'destroy' or 'retain')`)
     }
+  }
+
+  mergeMetadata({ data = {}, deletion_policy = "destroy" }) {
+    this.validateDeletionPolicty(deletion_policy)
     return { ...this.defaultMetadata, ...data, deletion_policy }
   }
 

--- a/commands/DeployCommand.js
+++ b/commands/DeployCommand.js
@@ -87,14 +87,17 @@ class DeployCommand {
     throw new Error([name, error.description].join(' => '))
   }
 
-  mergeMetadata(data = {}) {
-    return { ...this.defaultMetadata, ...data }
+  mergeMetadata({ data = {}, deletion_policy = "destroy" }) {
+    return { ...this.defaultMetadata, ...data, deletion_policy }
   }
 
   collectionAdapter(collection) {
     return {
       ...collection,
-      data: this.mergeMetadata(collection.data),
+      data: this.mergeMetadata({
+        data: collection.data,
+        deletion_policy: collection.deletion_policy,
+      }),
     }
   }
 
@@ -102,7 +105,10 @@ class DeployCommand {
     try {
       return {
         ...fn,
-        data: this.mergeMetadata(fn.data),
+        data: this.mergeMetadata({
+          data: fn.data,
+          deletion_policy: fn.deletion_policy,
+        }),
         role: fn.role
           ? ['admin', 'server'].includes(fn.role)
             ? fn.role
@@ -119,7 +125,10 @@ class DeployCommand {
     try {
       return {
         ...index,
-        data: this.mergeMetadata(index.data),
+        data: this.mergeMetadata({
+          data: index.data,
+          deletion_policy: index.deletion_policy,
+        }),
         source: (Array.isArray(index.source)
           ? index.source
           : [index.source]
@@ -207,7 +216,10 @@ class DeployCommand {
     try {
       const adaptedRole = {
         ...role,
-        data: this.mergeMetadata(role.data),
+        data: this.mergeMetadata({
+          data: role.data,
+          deletion_policy: role.deletion_policy,
+        }),
       }
 
       if (membership) {

--- a/schemaProps/collection.js
+++ b/schemaProps/collection.js
@@ -4,6 +4,7 @@ module.exports = {
   additionalProperties: false,
   properties: {
     name: { type: 'string' },
+    deletion_policy: { type: 'string' },
     data: { type: 'object' },
     history_days: { type: 'integer' },
     ttl_days: { type: 'integer' },

--- a/schemaProps/function.js
+++ b/schemaProps/function.js
@@ -4,6 +4,7 @@ module.exports = {
   additionalProperties: false,
   properties: {
     name: { type: 'string' },
+    deletion_policy: { type: 'string' },
     body: { type: 'string' },
     data: { type: 'object' },
     role: { type: 'string' },

--- a/schemaProps/index.js
+++ b/schemaProps/index.js
@@ -53,6 +53,7 @@ module.exports = {
   type: 'object',
   properties: {
     name: { type: 'string' },
+    deletion_policy: { type: 'string' },
     active: { type: 'boolean' },
     source: {
       oneOf: [

--- a/schemaProps/role.js
+++ b/schemaProps/role.js
@@ -86,6 +86,7 @@ module.exports = {
   required: ['name', 'privileges'],
   properties: {
     name: { type: 'string' },
+    deletion_policy: { type: 'string' },
     membership: {
       anyOf: [
         { type: 'string' },


### PR DESCRIPTION
Adds deletion policy to every resource. This will override whatever
the top-level deletion policy is.

Additionally, this PR also validates all deletion policies are either
'destroy' or 'retain', which it has not done in the past. This is a breaking
change, and should probably be included in the `0.2.0` release.
