### PR TITLE
Use a single top-level prop for fauna schemas

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -46,4 +46,6 @@ jobs:
           npm install
 
       - name: Test
-        run: npm test
+        run: |
+          npm test
+          npm run examples

--- a/__tests__/commands/FQL10Collections.test.js
+++ b/__tests__/commands/FQL10Collections.test.js
@@ -54,6 +54,7 @@ describe("FQL 10 Collections", () => {
   });
 
   afterAll(async () => {
+    await cleanup(client);
     client.close();
   });
 

--- a/__tests__/commands/FQL10Common.test.js
+++ b/__tests__/commands/FQL10Common.test.js
@@ -99,6 +99,7 @@ describe("FQL 10 Common", () => {
   });
 
   afterAll(async () => {
+    await cleanup(client);
     client.close();
   });
 

--- a/__tests__/commands/FQL10Functions.test.js
+++ b/__tests__/commands/FQL10Functions.test.js
@@ -38,6 +38,7 @@ describe("FQL 10 Functions", () => {
   });
 
   afterAll(async () => {
+    await cleanup(client);
     client.close();
   });
 

--- a/__tests__/commands/FQL10Roles.test.js
+++ b/__tests__/commands/FQL10Roles.test.js
@@ -54,6 +54,7 @@ describe("FQL 10 Roles", () => {
   });
 
   afterAll(async () => {
+    await cleanup(client);
     client.close();
   });
 

--- a/__tests__/commands/FaunaCommands.test.js
+++ b/__tests__/commands/FaunaCommands.test.js
@@ -9,17 +9,18 @@ const Logger = require("../../Logger");
 const getFql4Client = require("../../fauna/v4/client");
 const getFqlxClient = require("../../fauna/v10/client");
 const { cleanup } = require("../utils/cleanup");
+const {verifyLogs} = require("../utils/verify");
 
 describe("FaunaCommands", () => {
-  let fqlxClient;
+  let fql10Client;
   let fql4Client;
   const log = jest.fn();
   const logger = new Logger({ log });
-  let fqlxCommands, fql4DeployCommand, fql4RemoveCommand, faunaCommands;
+  let fql10Commands, fql4DeployCommand, fql4RemoveCommand;
 
-  const fqlxConfig = {
+  const fql10Config = {
     functions: {
-      FQLXFunc: {
+      FQLv10Func: {
         body: "_ => 1",
       },
     },
@@ -27,24 +28,20 @@ describe("FaunaCommands", () => {
 
   const fql4Config = {
     functions: {
-      FQL4Func: {
-        name: "FQL4Func",
+      FQLv4Func: {
+        name: "FQLv4Func",
         body: "Lambda('x', Var('x'))",
       },
     },
   };
 
-  const verify = async (logs) => {
-    expect(log.mock.calls.map((c) => c[0])).toEqual(logs);
-  };
-
   beforeAll(async () => {
     fql4Client = getFql4Client(clientConfig);
-    fqlxClient = getFqlxClient(clientConfig);
+    fql10Client = getFqlxClient(clientConfig);
 
-    fqlxCommands = new FQL10Commands({
-      config: fqlxConfig,
-      faunaClient: fqlxClient,
+    fql10Commands = new FQL10Commands({
+      config: fql10Config,
+      faunaClient: fql10Client,
       logger,
     });
 
@@ -60,95 +57,61 @@ describe("FaunaCommands", () => {
       logger,
     });
 
-    faunaCommands = new FaunaCommands(
-      {
-        fauna: { ...fql4Config },
-        fqlx: { ...fqlxConfig },
-      },
-      [fqlxCommands, fql4DeployCommand],
-      [fql4RemoveCommand, fqlxCommands]
-    );
   });
 
   beforeEach(async () => {
-    await cleanup(fqlxClient);
+    await cleanup(fql10Client);
   });
 
   afterAll(async () => {
     fql4Client.close();
-    fqlxClient.close();
+    fql10Client.close();
   });
 
-  it("deploys all in expected order", async () => {
-    await faunaCommands.deploy();
+  it("deploys and removes fql v10", async () => {
+    const faunaCommands = new FaunaCommands({
+      deployCommand: fql10Commands,
+      removeCommand: fql10Commands
+    })
 
-    const expectedLogs = [
+    // Run deploy
+    await faunaCommands.deploy();
+    let expectedLogs = [
       "FQL v10 schema update in progress...",
-      "Function: FQLXFunc created",
+      "Function: FQLv10Func created",
       "FQL v10 schema update complete",
-      "Schema updating in process...",
-      "function `FQL4Func` was created",
     ];
+    await verifyLogs(log, expectedLogs);
 
-    await verify(expectedLogs);
-  });
-
-  it("removes all in expected order", async () => {
-    await faunaCommands.deploy();
-    log.mockClear();
+    // Run remove
     await faunaCommands.remove();
-    const expectedLogs = [
-      'Resource Function("FQL4Func") deleted',
+    expectedLogs = [
       "FQL v10 schema remove in progress...",
-      "Function: FQLXFunc deleted",
+      "Function: FQLv10Func deleted",
       "FQL v10 schema remove complete",
     ];
-
-    await verify(expectedLogs);
+    await verifyLogs(log, expectedLogs);
   });
 
-  it("deploys only fqlx", async () => {
-    await faunaCommands.deployFqlx();
+  it("deploys and removes fql v4", async () => {
+    const faunaCommands = new FaunaCommands({
+      deployCommand: fql4DeployCommand,
+      removeCommand: fql4RemoveCommand,
+    })
 
-    const expectedLogs = [
-      "FQL v10 schema update in progress...",
-      "Function: FQLXFunc created",
-      "FQL v10 schema update complete",
-    ];
-
-    await verify(expectedLogs);
-  });
-
-  it("removes only fqlx", async () => {
+    // Run deploy
     await faunaCommands.deploy();
-    log.mockClear();
-    await faunaCommands.removeFqlx();
-    const expectedLogs = [
-      "FQL v10 schema remove in progress...",
-      "Function: FQLXFunc deleted",
-      "FQL v10 schema remove complete",
+    let expectedLogs = [
+      "FQL v4 schema update in progress...",
+      "function `FQLv4Func` was created",
     ];
+    await verifyLogs(log, expectedLogs);
 
-    await verify(expectedLogs);
-  });
-
-  it("deploys only fql4", async () => {
-    await faunaCommands.deployFql4();
-
-    const expectedLogs = [
-      "Schema updating in process...",
-      "function `FQL4Func` was created",
+    // Run remove
+    await faunaCommands.remove();
+    expectedLogs = [
+      "Resource Function(\"FQLv4Func\") deleted",
     ];
-
-    await verify(expectedLogs);
-  });
-
-  it("removes only fql4", async () => {
-    await faunaCommands.deploy();
-    log.mockClear();
-    await faunaCommands.removeFql4();
-    const expectedLogs = ['Resource Function("FQL4Func") deleted'];
-
-    await verify(expectedLogs);
+    await verifyLogs(log, expectedLogs);
   });
 });

--- a/__tests__/commands/FaunaCommands.test.js
+++ b/__tests__/commands/FaunaCommands.test.js
@@ -9,7 +9,7 @@ const Logger = require("../../Logger");
 const getFql4Client = require("../../fauna/v4/client");
 const getFqlxClient = require("../../fauna/v10/client");
 const { cleanup } = require("../utils/cleanup");
-const {verifyLogs} = require("../utils/verify");
+const { verifyLogs } = require("../utils/verify");
 
 describe("FaunaCommands", () => {
   let fql10Client;
@@ -56,7 +56,6 @@ describe("FaunaCommands", () => {
       faunaClient: fql4Client,
       logger,
     });
-
   });
 
   beforeEach(async () => {
@@ -71,8 +70,8 @@ describe("FaunaCommands", () => {
   it("deploys and removes fql v10", async () => {
     const faunaCommands = new FaunaCommands({
       deployCommand: fql10Commands,
-      removeCommand: fql10Commands
-    })
+      removeCommand: fql10Commands,
+    });
 
     // Run deploy
     await faunaCommands.deploy();
@@ -97,7 +96,7 @@ describe("FaunaCommands", () => {
     const faunaCommands = new FaunaCommands({
       deployCommand: fql4DeployCommand,
       removeCommand: fql4RemoveCommand,
-    })
+    });
 
     // Run deploy
     await faunaCommands.deploy();
@@ -109,9 +108,7 @@ describe("FaunaCommands", () => {
 
     // Run remove
     await faunaCommands.remove();
-    expectedLogs = [
-      "Resource Function(\"FQLv4Func\") deleted",
-    ];
+    expectedLogs = ['Resource Function("FQLv4Func") deleted'];
     await verifyLogs(log, expectedLogs);
   });
 });

--- a/__tests__/commands/FaunaCommands.test.js
+++ b/__tests__/commands/FaunaCommands.test.js
@@ -6,14 +6,14 @@ const FaunaCommands = require("../../commands/FaunaCommands");
 const { fql } = require("fauna");
 const clientConfig = require("../config");
 const Logger = require("../../Logger");
-const getFql4Client = require("../../fauna/v4/client");
-const getFqlxClient = require("../../fauna/v10/client");
+const getV4Client = require("../../fauna/v4/client");
+const getV10Client = require("../../fauna/v10/client");
 const { cleanup } = require("../utils/cleanup");
 const { verifyLogs } = require("../utils/verify");
 
 describe("FaunaCommands", () => {
-  let fql10Client;
-  let fql4Client;
+  let v10Client;
+  let v4Client;
   const log = jest.fn();
   const logger = new Logger({ log });
   let fql10Commands, fql4DeployCommand, fql4RemoveCommand;
@@ -36,35 +36,35 @@ describe("FaunaCommands", () => {
   };
 
   beforeAll(async () => {
-    fql4Client = getFql4Client(clientConfig);
-    fql10Client = getFqlxClient(clientConfig);
+    v4Client = getV4Client(clientConfig);
+    v10Client = getV10Client(clientConfig);
 
     fql10Commands = new FQL10Commands({
       config: fql10Config,
-      faunaClient: fql10Client,
+      faunaClient: v10Client,
       logger,
     });
 
     fql4DeployCommand = new FQL4DeployCommand({
       config: fql4Config,
-      faunaClient: fql4Client,
+      faunaClient: v4Client,
       logger,
     });
 
     fql4RemoveCommand = new FQL4RemoveCommand({
       config: fql4Config,
-      faunaClient: fql4Client,
+      faunaClient: v4Client,
       logger,
     });
   });
 
   beforeEach(async () => {
-    await cleanup(fql10Client);
+    await cleanup(v10Client);
   });
 
   afterAll(async () => {
-    fql4Client.close();
-    fql10Client.close();
+    v4Client.close();
+    v10Client.close();
   });
 
   it("deploys and removes fql v10", async () => {

--- a/commands/FQL4DeployCommand.js
+++ b/commands/FQL4DeployCommand.js
@@ -22,7 +22,7 @@ class FQL4DeployCommand {
       roles = {},
     } = this.config;
     try {
-      this.logger.info("Schema updating in process...");
+      this.logger.info("FQL v4 schema update in progress...");
 
       const queries = DeployQueries({
         roles: this.splitAndAdaptRoles(Object.values(roles)),
@@ -54,7 +54,7 @@ class FQL4DeployCommand {
       }
 
       if (!isSchemaUpdated) {
-        this.logger.success("Schema up to date");
+        this.logger.info("FQL v4 schema up to date");
       }
     } catch (error) {
       this.logger.error(error);

--- a/commands/FaunaCommands.js
+++ b/commands/FaunaCommands.js
@@ -1,129 +1,42 @@
-const FQL10Commands = require("./FQL10Commands");
-const FQL4DeployCommand = require("./FQL4DeployCommand");
-const FQL4RemoveCommand = require("./FQL4RemoveCommand");
-
 class FaunaCommands {
   /**
-   *  Takes an ordered list of deploy and remove commands and constructs
-   *  a FaunaCommands instance.
+   *  Takes a deploy and remove command and hooks them into serverless deploy and remove.
    *
-   * @param config the top level config provided by serverless
-   * @param deployCommands An ordered list of deploy commands.
-   * @param removeCommands An ordered list of remove commands.
+   * @param deployCommand A deploy command.
+   * @param removeCommand A remove command.
    */
-  constructor(config, deployCommands, removeCommands) {
-    this.config = config;
-    this.deployCommands = deployCommands;
-    this.removeCommands = removeCommands;
+  constructor({deployCommand, removeCommand}) {
+    this.deployCommand = deployCommand;
+    this.removeCommand = removeCommand;
 
     this.command = {
       deploy: {
         usage:
-          "Deploy all schema definitions. FQL X resources are deployed first.",
+          "Deploy the fauna schema definition.",
         lifecycleEvents: ["deploy"],
       },
       remove: {
         usage:
-          "Remove all schema definitions. FQL X resources are removed last.",
+          "Remove all schema managed by this plugin.",
         lifecycleEvents: ["remove"],
-      },
-      fqlx: {
-        commands: {
-          deploy: {
-            usage: "Deploy only FQL X schema definitions. (beta)",
-            lifecycleEvents: ["deploy"],
-          },
-          remove: {
-            usage: "Remove only FQL X schema definitions. (beta)",
-            lifecycleEvents: ["remove"],
-          },
-        },
-      },
-      fql4: {
-        commands: {
-          deploy: {
-            usage: "Deploy only FQL 4 schema definitions.",
-            lifecycleEvents: ["deploy"],
-          },
-          remove: {
-            usage: "Remove only FQL 4 schema definitions.",
-            lifecycleEvents: ["remove"],
-          },
-        },
       },
     };
 
     this.hooks = {
       "deploy:deploy": this.deploy.bind(this),
       "fauna:deploy:deploy": this.deploy.bind(this),
-      "fauna:fqlx:deploy:deploy": this.deployFqlx.bind(this),
-      "fauna:fql4:deploy:deploy": this.deployFql4.bind(this),
 
       "remove:remove": this.remove.bind(this),
       "fauna:remove:remove": this.remove.bind(this),
-      "fauna:fqlx:remove:remove": this.removeFqlx.bind(this),
-      "fauna:fql4:remove:remove": this.removeFql4.bind(this),
     };
   }
 
   async deploy() {
-    for (const cmd of this.deployCommands) {
-      await cmd.deploy();
-    }
+    await this.deployCommand.deploy();
   }
 
   async remove() {
-    for (const cmd of this.removeCommands) {
-      await cmd.remove();
-    }
-  }
-
-  async deployFqlx() {
-    if (this.config.fqlx == null) {
-      throw new Error("No `fqlx` schema defined.");
-    }
-
-    for (const cmd of this.deployCommands) {
-      if (cmd instanceof FQL10Commands) {
-        await cmd.deploy();
-      }
-    }
-  }
-
-  async removeFqlx() {
-    if (this.config.fqlx == null) {
-      throw new Error("No `fqlx` schema defined.");
-    }
-
-    for (const cmd of this.removeCommands) {
-      if (cmd instanceof FQL10Commands) {
-        await cmd.remove();
-      }
-    }
-  }
-
-  async deployFql4() {
-    if (this.config.fauna == null) {
-      throw new Error("No `fauna` (FQL 4) schema defined.");
-    }
-
-    for (const cmd of this.deployCommands) {
-      if (cmd instanceof FQL4DeployCommand) {
-        await cmd.deploy();
-      }
-    }
-  }
-
-  async removeFql4() {
-    if (this.config.fauna == null) {
-      throw new Error("No `fauna` (FQL 4) schema defined.");
-    }
-
-    for (const cmd of this.removeCommands) {
-      if (cmd instanceof FQL4RemoveCommand) {
-        await cmd.remove();
-      }
-    }
+    await this.removeCommand.remove();
   }
 }
 

--- a/commands/FaunaCommands.js
+++ b/commands/FaunaCommands.js
@@ -5,19 +5,17 @@ class FaunaCommands {
    * @param deployCommand A deploy command.
    * @param removeCommand A remove command.
    */
-  constructor({deployCommand, removeCommand}) {
+  constructor({ deployCommand, removeCommand }) {
     this.deployCommand = deployCommand;
     this.removeCommand = removeCommand;
 
     this.command = {
       deploy: {
-        usage:
-          "Deploy the fauna schema definition.",
+        usage: "Deploy the fauna schema definition.",
         lifecycleEvents: ["deploy"],
       },
       remove: {
-        usage:
-          "Remove all schema managed by this plugin.",
+        usage: "Remove all schema managed by this plugin.",
         lifecycleEvents: ["remove"],
       },
     };

--- a/concourse/docker-compose-fauna.yml
+++ b/concourse/docker-compose-fauna.yml
@@ -20,6 +20,7 @@ services:
       FAUNA_DOMAIN: faunadb
       FAUNA_PORT: 8443
       FAUNA_SECRET: secret
+      FAUNA_ENDPOINT: http://faunadb:8443
     command:
       - /bin/sh
       - -cxe
@@ -28,3 +29,4 @@ services:
         ./concourse/scripts/wait-for-it.sh http://faunadb:8443/ping
         npm install
         npm run test
+        npm run examples

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,3 @@
+/node_modules/
+yarn.lock
+package-lock.json

--- a/examples/package.json
+++ b/examples/package.json
@@ -5,6 +5,7 @@
     "help": "sls fauna --help -c serverless-v10.yml && sls fauna deploy --help -c serverless-v10.yml && sls fauna remove --help -c serverless-v10.yml"
   },
   "devDependencies": {
-    "@fauna-labs/serverless-fauna": "file:../"
+    "@fauna-labs/serverless-fauna": "file:../",
+    "serverless": "^3.32.2"
   }
 }

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "deploy-v10": "sls fauna deploy -c serverless-v10.yml && sls fauna remove -c serverless-v10.yml",
+    "deploy-v4": "sls fauna deploy -c serverless-v4.yml && sls fauna remove -c serverless-v4.yml",
+    "help": "sls fauna --help -c serverless-v10.yml && sls fauna deploy --help -c serverless-v10.yml && sls fauna remove --help -c serverless-v10.yml"
+  },
+  "devDependencies": {
+    "@fauna-labs/serverless-fauna": "file:../"
+  }
+}

--- a/examples/serverless-v10.yml
+++ b/examples/serverless-v10.yml
@@ -1,0 +1,66 @@
+service: sample-v10
+
+plugins:
+  - "@fauna-labs/serverless-fauna"
+
+provider: # dummy values
+  name: aws
+  runtime: nodejs14.x
+
+fauna:
+  version: 10
+  deletion_policy: destroy
+  client:
+    secret: ${env:FAUNA_SECRET, "secret"}
+    endpoint: ${env:FAUNA_ENDPOINT, "http://localhost:8443"}
+
+  collections:
+    UsersV10: {}
+    CollV10:
+      constraints:
+        - unique: name
+      indexes:
+        byName:
+          queryable: false
+          terms:
+            - field: name
+        byDateOfBirth:
+          terms:
+            - field: date_of_birth
+          values:
+            - field: date_of_birth
+              order: desc
+
+  functions:
+    FuncV10:
+      body: _ => 1
+      role: FuncV10Role
+
+  roles:
+    FuncV10Role:
+      privileges:
+        - resource: CollV10
+          actions:
+            read: true
+            write: true
+    RoleV10:
+      privileges:
+        - resource: CollV10
+          actions:
+            read: true
+            write: |
+              (before, after) => true
+        - resource: FuncV10
+          actions:
+            call: true
+    MembershipRoleV10:
+      membership:
+        - resource: UsersV10
+          predicate: user => user.isAdmin
+      privileges:
+        - resource: CollV10
+          actions:
+            read: true
+            write: true
+            create: true
+            delete: true

--- a/examples/serverless-v4.yml
+++ b/examples/serverless-v4.yml
@@ -1,0 +1,46 @@
+service: sample-v4
+
+plugins:
+  - "@fauna-labs/serverless-fauna"
+
+provider: # dummy values
+  name: aws
+  runtime: nodejs14.x
+
+fauna:
+  version: 4
+  deletion_policy: destroy
+  client:
+    secret: ${env:FAUNA_SECRET, "secret"}
+    domain: ${env:FAUNA_DOMAIN, "localhost"}
+    scheme: ${env:FAUNA_SCHEME, "http"}
+    port: ${env:FAUNA_PORT, "8443"}
+
+  collections:
+    CollV4:
+      name: CollV4
+
+  indexes:
+    IndexV4:
+      name: IndexV4
+      source: CollV4
+      terms:
+        fields:
+          - data.name
+
+  functions:
+    FuncV4:
+      name: FuncV4
+      body: Lambda("p", Var("p"))
+
+  roles:
+    RoleV4:
+      name: RoleV4
+      privileges:
+        - collection: CollV4
+          actions:
+            read: true
+            write: true
+        - function: FuncV4
+          actions:
+            call: true

--- a/fauna/v10/client.js
+++ b/fauna/v10/client.js
@@ -1,6 +1,6 @@
 const { Client } = require("fauna");
 
-function getFQLXClient({ secret, endpoint, scheme, port, domain }) {
+function getV10Client({ secret, endpoint, scheme, port, domain }) {
   if (endpoint != null && (scheme != null || port != null || domain != null)) {
     throw new Error(
       "Configure the client with `endpoint` or `schema`, `domain` and `port`, but not both."
@@ -27,4 +27,4 @@ function getFQLXClient({ secret, endpoint, scheme, port, domain }) {
   }
 }
 
-module.exports = getFQLXClient;
+module.exports = getV10Client;

--- a/fauna/v10/schema/collection.js
+++ b/fauna/v10/schema/collection.js
@@ -22,6 +22,7 @@ module.exports = {
           type: "object",
           additionalProperties: false,
           properties: {
+            queryable: { type: "boolean" },
             terms: {
               type: "array",
               items: {

--- a/fauna/v10/schema/fauna.js
+++ b/fauna/v10/schema/fauna.js
@@ -8,6 +8,7 @@ module.exports = {
   required: ["client"],
   additionalProperties: false,
   properties: {
+    version: {},
     client: clientProp,
     deletion_policy: { type: "string" },
     functions: {

--- a/fauna/v4/schema/fauna.js
+++ b/fauna/v4/schema/fauna.js
@@ -9,6 +9,7 @@ module.exports = {
   required: ["client"],
   additionalProperties: false,
   properties: {
+    version: {},
     client: clientProp,
     deletion_policy: { type: "string" },
     collections: {

--- a/index.js
+++ b/index.js
@@ -25,82 +25,80 @@ class ServerlessFaunaPlugin {
       },
     };
 
-    // If --help is true, init with nothing and return
     if (options.help) {
+      // If --help is true, init with noops
       const cmd = new FaunaCommands({
-        deployCommand: null,
-        removeCommand: null,
+        deployCommand: async () => {},
+        removeCommand: async () => {},
       });
-      Object.assign(this.hooks, cmd.hooks);
-      Object.assign(this.commands.fauna.commands, cmd.command);
-      return;
-    }
-
-    this.config.fauna.version = this.config.fauna.version ?? "4";
-
-    if (
-      this.config.fauna.version === "10" ||
-      this.config.fauna.version === 10
-    ) {
-      this.serverless.configSchemaHandler.defineTopLevelProperty(
-        "fauna",
-        faunaV10Schema
-      );
-
-      const v10cmd = new FQL10Commands({
-        faunaClient: getV10Client(this.config.fauna.client),
-        serverless: this.serverless,
-        config: this.config.fauna,
-        options: this.options,
-        logger: this.logger,
-      });
-
-      const cmd = new FaunaCommands({
-        config: this.config,
-        deployCommand: v10cmd,
-        removeCommand: v10cmd,
-      });
-
-      Object.assign(this.hooks, cmd.hooks);
-      Object.assign(this.commands.fauna.commands, cmd.command);
-    } else if (
-      this.config.fauna.version === "4" ||
-      this.config.fauna.version === 4
-    ) {
-      this.serverless.configSchemaHandler.defineTopLevelProperty(
-        "fauna",
-        faunaV4Schema
-      );
-
-      const client = getV4Client(this.config.fauna.client);
-      const v4deploy = new FQL4DeployCommand({
-        faunaClient: client,
-        serverless: this.serverless,
-        config: this.config.fauna,
-        options: this.options,
-        logger: this.logger,
-      });
-
-      const v4remove = new FQL4RemoveCommand({
-        faunaClient: client,
-        serverless: this.serverless,
-        config: this.config.fauna,
-        options: this.options,
-        logger: this.logger,
-      });
-
-      const cmd = new FaunaCommands({
-        config: this.config,
-        deployCommand: v4deploy,
-        removeCommand: v4remove,
-      });
-
       Object.assign(this.hooks, cmd.hooks);
       Object.assign(this.commands.fauna.commands, cmd.command);
     } else {
-      throw new Error(
-        `Version must be '4' or '10', but was '${this.config.fauna.version}'`
-      );
+      this.config.fauna.version = this.config.fauna.version ?? "4";
+      if (
+        this.config.fauna.version === "10" ||
+        this.config.fauna.version === 10
+      ) {
+        this.serverless.configSchemaHandler.defineTopLevelProperty(
+          "fauna",
+          faunaV10Schema
+        );
+
+        const v10cmd = new FQL10Commands({
+          faunaClient: getV10Client(this.config.fauna.client),
+          serverless: this.serverless,
+          config: this.config.fauna,
+          options: this.options,
+          logger: this.logger,
+        });
+
+        const cmd = new FaunaCommands({
+          config: this.config,
+          deployCommand: v10cmd,
+          removeCommand: v10cmd,
+        });
+
+        Object.assign(this.hooks, cmd.hooks);
+        Object.assign(this.commands.fauna.commands, cmd.command);
+      } else if (
+        this.config.fauna.version === "4" ||
+        this.config.fauna.version === 4
+      ) {
+        this.serverless.configSchemaHandler.defineTopLevelProperty(
+          "fauna",
+          faunaV4Schema
+        );
+
+        const client = getV4Client(this.config.fauna.client);
+        const v4deploy = new FQL4DeployCommand({
+          faunaClient: client,
+          serverless: this.serverless,
+          config: this.config.fauna,
+          options: this.options,
+          logger: this.logger,
+        });
+
+        const v4remove = new FQL4RemoveCommand({
+          faunaClient: client,
+          serverless: this.serverless,
+          config: this.config.fauna,
+          options: this.options,
+          logger: this.logger,
+        });
+
+        const cmd = new FaunaCommands({
+          config: this.config,
+          deployCommand: v4deploy,
+          removeCommand: v4remove,
+        });
+
+        Object.assign(this.hooks, cmd.hooks);
+        Object.assign(this.commands.fauna.commands, cmd.command);
+      } else {
+        throw new Error(
+          `Version must be '4' or '10', but was '${this.config.fauna.version}'`
+        );
+      }
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -28,19 +28,20 @@ class ServerlessFaunaPlugin {
     // If --help is true, init with nothing and return
     if (options.help) {
       const cmd = new FaunaCommands({
-          deployCommand: null,
-          removeCommand: null,
-        }
-      );
+        deployCommand: null,
+        removeCommand: null,
+      });
       Object.assign(this.hooks, cmd.hooks);
       Object.assign(this.commands.fauna.commands, cmd.command);
-      return
+      return;
     }
 
-    this.config.fauna.version = this.config.fauna.version ?? "4"
+    this.config.fauna.version = this.config.fauna.version ?? "4";
 
-
-    if (this.config.fauna.version === "10" || this.config.fauna.version === 10) {
+    if (
+      this.config.fauna.version === "10" ||
+      this.config.fauna.version === 10
+    ) {
       this.serverless.configSchemaHandler.defineTopLevelProperty(
         "fauna",
         faunaV10Schema
@@ -55,15 +56,17 @@ class ServerlessFaunaPlugin {
       });
 
       const cmd = new FaunaCommands({
-          config: this.config,
-          deployCommand: v10cmd,
-          removeCommand: v10cmd,
-        }
-      );
+        config: this.config,
+        deployCommand: v10cmd,
+        removeCommand: v10cmd,
+      });
 
       Object.assign(this.hooks, cmd.hooks);
       Object.assign(this.commands.fauna.commands, cmd.command);
-    } else if (this.config.fauna.version ===  "4" || this.config.fauna.version === 4) {
+    } else if (
+      this.config.fauna.version === "4" ||
+      this.config.fauna.version === 4
+    ) {
       this.serverless.configSchemaHandler.defineTopLevelProperty(
         "fauna",
         faunaV4Schema
@@ -87,16 +90,17 @@ class ServerlessFaunaPlugin {
       });
 
       const cmd = new FaunaCommands({
-          config: this.config,
-          deployCommand: v4deploy,
-          removeCommand: v4remove,
-        }
-      );
+        config: this.config,
+        deployCommand: v4deploy,
+        removeCommand: v4remove,
+      });
 
       Object.assign(this.hooks, cmd.hooks);
       Object.assign(this.commands.fauna.commands, cmd.command);
     } else {
-      throw new Error(`Version must be '4' or '10', but was '${this.config.fauna.version}'`)
+      throw new Error(
+        `Version must be '4' or '10', but was '${this.config.fauna.version}'`
+      );
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,12 @@
   "scripts": {
     "lint": "prettier --write .",
     "lint-ci": "prettier --check .",
-    "test": "jest --coverage --runInBand"
+    "test": "jest --coverage --runInBand",
+    "test-examples-install": "cd examples && yarn install --no-lockfile",
+    "test-examples-deploy-v10": "cd examples && yarn deploy-v10",
+    "test-examples-deploy-v4": "cd examples && yarn deploy-v4",
+    "test-examples-help": "cd examples && yarn run help",
+    "examples": "yarn test-examples-help && yarn test-examples-install && yarn test-examples-deploy-v10 && yarn test-examples-deploy-v4"
   },
   "dependencies": {
     "fauna": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test-examples-deploy-v10": "cd examples && yarn deploy-v10",
     "test-examples-deploy-v4": "cd examples && yarn deploy-v4",
     "test-examples-help": "cd examples && yarn run help",
-    "examples": "yarn test-examples-help && yarn test-examples-install && yarn test-examples-deploy-v10 && yarn test-examples-deploy-v4"
+    "examples": "yarn test-examples-install && yarn test-examples-help && yarn test-examples-deploy-v10 && yarn test-examples-deploy-v4"
   },
   "dependencies": {
     "fauna": "^0.9.0",


### PR DESCRIPTION
## Changes

### Use single `fauna` top-level property
Before:
Single file
```
...

fqlx:
  ...

fauna:
  ...
```

After:
Multiple files
FQL v10
```
fauna:
  version: 10
  ...
```
FQL v4
```
fauna:
  version: 4 <-- optional b/c default is 4 for now
  ...
```

### Other changes
* Add missing `queryable` prop to indexes
* Add examples dir and run them as part of CI/CD
* Update logging to FQL v4 and FQL v10

## Testing
* Fixed tests that needed fixing
* Added e2e tests that run an actual serverless file