### PR TITLE
Version 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fauna-labs/serverless-fauna",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fauna-labs/serverless-fauna",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A plugin to define resources in your Fauna database directly within your Serverless Framework applications.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Changes
* Fixes a bug where the remove transaction happens even if the create/update transaction fails
* Improves deploy and remove query composition to allow for a larger number of resources
* Add support for Collections, including indexes and constraints
* Add support for Roles
* Remove support for declaring both v4 and v10 schema in a single file. Instead, move to single top-level property, `fauna`, with a version sub-property.

Before, in one file:

```
fqlx:
  ...

fauna:
  ...
```

After, in separate files:
```
fauna:
  version: 10
  ...
```
```
fauna:
  version: 4     # optional, default is 4
  ...
```
