### PR TITLE
Disable typechecking for realzies

### DIFF
--- a/fauna/v10/client.js
+++ b/fauna/v10/client.js
@@ -10,11 +10,13 @@ function getV10Client({ secret, endpoint, scheme, port, domain }) {
   if (endpoint == null && scheme == null && port == null && domain == null) {
     return new Client({
       secret,
+      typecheck: false,
     });
   } else if (endpoint != null) {
     return new Client({
       endpoint: new URL(endpoint),
       secret,
+      typecheck: false,
     });
   } else {
     scheme = scheme ?? "https";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fauna-labs/serverless-fauna",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A plugin to define resources in your Fauna database directly within your Serverless Framework applications.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I think I'm blind. We create a client in 3 places, and I only switched one over. Our tests don't test the `endpoint` setting or the default behavior, they only test the `domain`/`scheme`/`port` settings.
