### PR TITLE
Update dind image

### DIFF
--- a/concourse/tasks/run-tests.yml
+++ b/concourse/tasks/run-tests.yml
@@ -3,7 +3,10 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: karlkfi/concourse-dcind
+    repository: shared-concourse-dind
+    aws_access_key_id: ((prod-images-aws-access-key-id))
+    aws_secret_access_key: ((prod-images-aws-secret-key))
+    aws_region: us-east-2
 
 params:
   FAUNA_ROOT_KEY:


### PR DESCRIPTION
## Problem
The fauna docker container which tests are run against is not starting up in the pipeline.

## Solution
Try updating the image used to run the tests as was done here https://github.com/fauna/fauna-js/commit/5d351ce1b5cea6ac65d3d848957041e0b66dd082

## Result
Will hopefully fix the pipeline.

## Testing
The pipeline will test.