### PR TITLE
Bump version to 0.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fauna-labs/serverless-fauna",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "A plugin to define resources in your Fauna database directly within your Serverless Framework applications.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Notes
Bump the package version in preparation for release of support for `ttl_days` and `history_days` fields on collections.

Commit to be released: https://github.com/fauna-labs/serverless-fauna/commit/d5c7c74d5c3304edbe3b35c9b84e77cafc2b2a09